### PR TITLE
Feature/make fingerprinting optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ObserveRTC/observer-lib",
-  "version": "2103-27",
+  "version": "2103-28",
   "description": "Extractor Development Toolkits for WebRTC Samples",
   "main": "dist/latest/observer.js",
   "types": "dist/latest/observer.d.ts",

--- a/src/observer.collector/observer.builder/index.ts
+++ b/src/observer.collector/observer.builder/index.ts
@@ -33,6 +33,11 @@ class Builder {
         return this
     }
 
+    withBrowserId (browserId: string): Builder {
+        this.instance.setBrowserId(browserId)
+        return this
+    }
+
     build (): Observer {
         return this.instance
     }

--- a/src/observer.collector/observer.peer/index.ts
+++ b/src/observer.collector/observer.peer/index.ts
@@ -53,25 +53,20 @@ class ObserverPC {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call
     private readonly _id: string = uuidv4()
     private readonly _timeZoneOffsetInMinute: number = TimeUtil.getTimeZoneOffsetInMinute()
-    private _browserId?: string
     private readonly _rtcState = new RTCState()
 
     constructor (private readonly userConfig: UserConfig) {
         this.updateConnectionState = this.updateConnectionState.bind(this)
         this.getStats = this.getStats.bind(this)
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        observerSingleton.getBrowserId().then((value) => {
-            this._browserId = value
-        })
     }
 
     get id (): string {
         return this._id
     }
 
-    public getPcDetails (marker?: string): PCDetails {
+    public async getPcDetails (marker?: string, browserId?: string): Promise<PCDetails> {
         return {
-            'browserId': this._browserId,
+            'browserId': browserId ?? await observerSingleton.getBrowserId(),
             'callId': this.userConfig.callId,
             'clientDetails': BrowserUtil.getClientDetails(),
             'deviceList': observerSingleton.getActiveDeviceList(),

--- a/src/observer.collector/observer/index.ts
+++ b/src/observer.collector/observer/index.ts
@@ -110,6 +110,10 @@ class Observer implements ClientCallback, UserMediaCallback {
         this._collector.updateMarker(marker)
     }
 
+    public setBrowserId (browserId: string): void {
+        this._collector.setBrowserId(browserId)
+    }
+
     public addPC (pc: RTCPeerConnection, callId?: string, userId?: string): void {
         const userConfig = {
             callId,

--- a/src/observer.collector/rtc.collector/index.ts
+++ b/src/observer.collector/rtc.collector/index.ts
@@ -23,12 +23,17 @@ export interface UserMediaErrorPayload {
 
 class RTCCollector {
     private marker?: string
+    private browserId?: string
     constructor () {
         this.collect = this.collect.bind(this)
     }
 
     public updateMarker (marker: string): void {
         this.marker = marker
+    }
+
+    public setBrowserId (browserId: string): void {
+        this.browserId = browserId
     }
 
     public async collect (rtcList: ObserverPC[]): Promise<RawStats[]> {
@@ -39,7 +44,7 @@ class RTCCollector {
     public async collectUserMediaError (errName: string): Promise<UserMediaErrorPayload> {
         return {
             'details': {
-                'browserId': await observerSingleton.getBrowserId(),
+                'browserId': this.browserId ?? await observerSingleton.getBrowserId(),
                 'clientDetails': BrowserUtil.getClientDetails(),
                 'deviceList': await BrowserUtil.getDeviceList(),
                 'marker': this.marker,
@@ -52,7 +57,10 @@ class RTCCollector {
 
     private async collectStats (observerPc: ObserverPC): Promise<RawStats> {
         const stats = await observerPc.getStats()
-        const pcDetails = observerPc.getPcDetails(this.marker)
+        const pcDetails = await observerPc.getPcDetails(
+            this.marker,
+            this.browserId
+        )
         return {
             'details': pcDetails,
             stats

--- a/src/observer.singleton/index.ts
+++ b/src/observer.singleton/index.ts
@@ -47,8 +47,6 @@ class ObserverSingleton {
 }
 
 const observerSingleton = new ObserverSingleton()
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
-observerSingleton.getBrowserId().catch()
 // Update active device list in the beginning
 observerSingleton.getActiveDeviceList()
 


### PR DESCRIPTION
For browser id generation we previously fingerprinting the browser.
Now, if you provide a custom browser id, it does not fingerprint the browser anymore