### PR TITLE
Add access token support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ObserveRTC/observer-lib",
-  "version": "2105-08",
+  "version": "2105-21",
   "description": "Extractor Development Toolkits for WebRTC Samples",
   "main": "dist/latest/observer.js",
   "types": "dist/latest/observer.d.ts",

--- a/src/observer.collector/observer.builder/index.ts
+++ b/src/observer.collector/observer.builder/index.ts
@@ -17,6 +17,7 @@ class Builder {
     private _marker?: string
     private _browserId?: string
     private _integration?: Integration
+    private _accessToken?: (() => string) | string
 
     constructor (initializeConfig: InitialConfig) {
         this._initialConfig = initializeConfig
@@ -46,11 +47,8 @@ class Builder {
         return this
     }
 
-    withAccessToken (accessToken?: string): Builder {
-        this._initialConfig = {
-            ...this._initialConfig,
-            ...accessToken && {accessToken}
-        }
+    withAccessToken (accessToken?: (() => string) | string): Builder {
+        this._accessToken = accessToken
         return this
     }
 
@@ -67,6 +65,9 @@ class Builder {
         }
         if (this._browserId) {
             instance.setBrowserId(this._browserId)
+        }
+        if (this._accessToken || typeof this._accessToken === 'function') {
+            instance.setAccessToken(this._accessToken)
         }
         return instance
     }

--- a/src/observer.collector/observer/index.ts
+++ b/src/observer.collector/observer/index.ts
@@ -41,6 +41,7 @@ class Observer implements ClientCallback, UserMediaCallback {
     private _rtcList: ObserverPC[] = []
     private _integration?: Integration
     private _localTransport?: LocalTransport
+    private _accessToken?: (() => string) | string
     private readonly _collector = new RTCCollector()
     private readonly _collectorWorker = new CollectorWorker(
         WorkerUrlManager.getURL(),
@@ -90,11 +91,28 @@ class Observer implements ClientCallback, UserMediaCallback {
     }
 
     onRequestInitialConfig (): void {
-        this._collectorWorker.sendInitialConfig(this._initializeConfig)
+        let accessToken = ''
+        if (typeof this._accessToken === 'function') {
+            accessToken = this._accessToken()
+        } else if (typeof this._accessToken === 'string') {
+            accessToken = this._accessToken
+        }
+        this._collectorWorker.sendInitialConfig({
+            ...this._initializeConfig,
+            ...accessToken && {accessToken}
+        })
     }
 
     onTransportCallback (peerConnectionSamples?: PeerConnectionSample[]): void {
         this._localTransport?.onObserverRTCSample?.(peerConnectionSamples)
+    }
+
+    onRequestAccessToken (): void {
+        if (typeof this._accessToken === 'function') {
+            this._collectorWorker.sendAccessToken(this._accessToken())
+        } else if (typeof this._accessToken === 'string') {
+            this._collectorWorker.sendAccessToken(this._accessToken)
+        }
     }
 
     public setIntegration (integration: Integration): void {
@@ -111,6 +129,10 @@ class Observer implements ClientCallback, UserMediaCallback {
 
     public setBrowserId (browserId: string): void {
         this._collector.setBrowserId(browserId)
+    }
+
+    public setAccessToken (accessToken?: (() => string) | string): void {
+        this._accessToken = accessToken
     }
 
     public addPC (pc: RTCPeerConnection, callId?: string, userId?: string): void {

--- a/src/observer.processor/observer/index.ts
+++ b/src/observer.processor/observer/index.ts
@@ -32,13 +32,16 @@ import {
 import {
     StatsOptimizer
 } from '../rtc.stats.optimizer'
+import type {
+    WsTransportCallback
+} from '../websocket.transport'
 import {
     WebSocketTransport
 } from '../websocket.transport'
 
 
 const defaultIntervalDurationInMs = 1000
-class ObserverProcessor implements WorkerCallback {
+class ObserverProcessor implements WorkerCallback, WsTransportCallback {
     private readonly _cron = new CronInterval()
     private readonly _statsOptimizer = new StatsOptimizer()
     private readonly _integrationOptimizer = new IntegrationOptimizer()
@@ -52,6 +55,7 @@ class ObserverProcessor implements WorkerCallback {
         this.onResponseRawStats = this.onResponseRawStats.bind(this)
         this.onResponseInitialConfig = this.onResponseInitialConfig.bind(this)
         this.sendDataToTransport = this.sendDataToTransport.bind(this)
+        this.onAccessToken = this.onAccessToken.bind(this)
         // eslint-disable-next-line no-console
         console.warn(
             '$ObserverRTC version[processor]',
@@ -62,6 +66,7 @@ class ObserverProcessor implements WorkerCallback {
             __buildDate__
         )
     }
+
     get messageHandler (): any {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         return this._processorWorker.onMessage
@@ -129,17 +134,27 @@ class ObserverProcessor implements WorkerCallback {
         )
     }
 
+    onAccessToken (accessToken: string): void {
+        this._webSocketTransport?.updateAccessToken(accessToken)
+    }
+
+    requestAccessToken (): void {
+        this._processorWorker.requestAccessToken()
+    }
+
     private startWsServer (wsServerAddress: string, accessToken?: string): void {
         logger.warn(
             'start websocket server',
-            wsServerAddress
+            wsServerAddress,
+            accessToken
         )
         if (this._webSocketTransport) {
             this._webSocketTransport.dispose()
         }
         this._webSocketTransport = new WebSocketTransport(
             wsServerAddress,
-            accessToken
+            accessToken,
+            this
         )
     }
 

--- a/src/observer.processor/websocket.transport/index.ts
+++ b/src/observer.processor/websocket.transport/index.ts
@@ -6,12 +6,29 @@ import {
 import type {
     PeerConnectionSample
 } from '../../schema/v20200114'
-
+export interface SocketError {
+    code: number;
+    reason: string;
+}
+const knownErrorCodes = [
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    4224,
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    4225,
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    4226,
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    4227
+]
 class WebSocketTransport {
     private _webSocket?: ReconnectingWebSocket
-    constructor (wsServerAddress: string, accessToken?: string) {
+    private readonly _wsServerAddress: string
+    private _accessToken?: string
+    constructor (wsServerAddress: string, accessToken?: string, wsTransportCallback?: WsTransportCallback) {
         this.send = this.send.bind(this)
         this.sendBulk = this.sendBulk.bind(this)
+        this.serverAddress = this.serverAddress.bind(this)
+        this.updateAccessToken = this.updateAccessToken.bind(this)
         if (!wsServerAddress) {
             throw new Error('websocket server address is required')
         }
@@ -22,12 +39,10 @@ class WebSocketTransport {
             'maxEnqueuedMessages': 120,
             'maxRetries': 100
         }
-        const serverUrl = this.serverAddress(
-            wsServerAddress,
-            accessToken
-        )
+        this._wsServerAddress = wsServerAddress
+        this._accessToken = accessToken
         this._webSocket = new ReconnectingWebSocket(
-            serverUrl,
+            () => this.serverAddress(),
             [],
             options
         )
@@ -36,6 +51,10 @@ class WebSocketTransport {
                 'websocket closed',
                 close
             )
+            const {code} = close
+            if (knownErrorCodes.includes(code)) {
+                wsTransportCallback?.requestAccessToken()
+            }
         }
         this._webSocket.onerror = (err): void => {
             logger.warn(
@@ -51,11 +70,11 @@ class WebSocketTransport {
         }
     }
 
-    serverAddress (wsServerAddress: string, accessToken?: string): string {
-        if (!accessToken) {
-            return wsServerAddress
+    serverAddress (): string {
+        if (!this._accessToken) {
+            return this._wsServerAddress
         }
-        return `${wsServerAddress}?accessToken=${accessToken}`
+        return `${this._wsServerAddress}?accessToken=${this._accessToken}`
     }
 
     public dispose (): void {
@@ -77,8 +96,15 @@ class WebSocketTransport {
             this.send(currentPayload)
         })
     }
+
+    public updateAccessToken (accessToken?: string): void {
+        this._accessToken = accessToken
+    }
 }
 
+export interface WsTransportCallback {
+    requestAccessToken: () => void;
+}
 export {
     WebSocketTransport
 }

--- a/src/observer.worker/collector.wrapper/index.ts
+++ b/src/observer.worker/collector.wrapper/index.ts
@@ -53,6 +53,14 @@ class CollectorWorker {
         this._worker.postMessage(payload)
     }
 
+    public sendAccessToken (accessToken?: string): void {
+        const payload = {
+            'data': accessToken,
+            'what': 'onRequestAccessToken'
+        } as ClientPayload
+        this._worker.postMessage(payload)
+    }
+
     public onError (err: any): void {
         logger.error(err)
         this._clientCallback?.onError(err)
@@ -69,6 +77,9 @@ class CollectorWorker {
                 return
             case 'onLocalTransport':
                 this._clientCallback?.onTransportCallback(data.data)
+                return
+            case 'requestAccessToken':
+                this._clientCallback?.onRequestAccessToken()
                 return
             default:
                 logger.warn(

--- a/src/observer.worker/processor.wrapper/index.ts
+++ b/src/observer.worker/processor.wrapper/index.ts
@@ -42,6 +42,9 @@ class ProcessorWorker {
             case 'onUserMediaError':
                 this._workerCallback?.onUserMediaError(data.data as UserMediaErrorPayload)
                 return
+            case 'onRequestAccessToken':
+                this._workerCallback?.onAccessToken(data.data as string)
+                return
             default:
                 logger.warn(
                     'unknown types',
@@ -53,6 +56,11 @@ class ProcessorWorker {
     requestInitialConfig (): void {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
         this._workerScope.postMessage({'what': 'requestInitialConfig'} as WorkerPayload)
+    }
+
+    requestAccessToken (): void {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+        this._workerScope.postMessage({'what': 'requestAccessToken'} as WorkerPayload)
     }
 
     requestRawStats (): void {

--- a/src/observer.worker/types/index.ts
+++ b/src/observer.worker/types/index.ts
@@ -12,8 +12,10 @@ type RequestInitialConfig = 'requestInitialConfig'
 type OnRequestInitialConfig = 'onRequestInitialConfig'
 type OnUserMediaError = 'onUserMediaError'
 type OnLocalTransport = 'onLocalTransport'
+type RequestAccessToken = 'requestAccessToken'
+type OnRequestAccessToken = 'onRequestAccessToken'
 
-type Data = RawStats[] | InitialConfig | UserMediaErrorPayload
+type Data = RawStats[] | InitialConfig | UserMediaErrorPayload | string
 
 // Default transport will be remote ( websocket )
 export type TransportType = 'local' | 'remote'
@@ -26,12 +28,12 @@ export interface InitialConfig {
 }
 
 export interface ClientPayload {
-    what: OnRequestRawStats | OnRequestInitialConfig | OnUserMediaError;
+    what: OnRequestRawStats | OnRequestInitialConfig | OnUserMediaError | OnRequestAccessToken;
     data: Data;
 }
 
 export interface WorkerPayload {
-    what: RequestRawStats | RequestInitialConfig | OnLocalTransport;
+    what: RequestRawStats | RequestInitialConfig | OnLocalTransport | RequestAccessToken;
     data?: PeerConnectionSample[];
 }
 
@@ -39,6 +41,7 @@ export interface ClientCallback {
     onRequestRawStats: () => void;
     onRequestInitialConfig: () => void;
     onTransportCallback: (peerConnectionSamples?: PeerConnectionSample[]) => void;
+    onRequestAccessToken: () => void;
     onError: (err: any) => void;
 }
 
@@ -46,4 +49,5 @@ export interface WorkerCallback {
     onResponseRawStats: (rawStats: RawStats[]) => void;
     onResponseInitialConfig: (rawStats: InitialConfig) => void;
     onUserMediaError: (mediaError: UserMediaErrorPayload) => void;
+    onAccessToken: (accessToken: string) => void;
 }


### PR DESCRIPTION
Observer JS core now supports passing access token via
 - access token as a string
 - or access token as a function


`(() => string) | string`